### PR TITLE
chore(ci): set up travis and appveyor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+.nyc_output/
+coverage/
+node_modules/
+test/resources/
+test/tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+sudo: false
+node_js:
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
+  - 11
+
+os:
+  - linux
+  - osx
+script:
+  - npm run test-with-coverage
+  - npm run lint
+after_success:
+  - npm run codecov -- -f coverage/lcov.info
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Shjs
 
-[![Travis](https://img.shields.io/travis/shelljs.shjs/master.svg?style=flat-square&label=unix)](https://travis-ci.org/shelljs.shjs)
-[![AppVeyor](https://img.shields.io/appveyor/ci/shelljs.shjs/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/shelljs.shjs/branch/master)
-[![Codecov](https://img.shields.io/codecov/c/github/shelljs.shjs/master.svg?style=flat-square&label=coverage)](https://codecov.io/gh/shelljs.shjs)
-[![npm version](https://img.shields.io/npm/v/shelljs.svg?style=flat-square)](https://www.npmjs.com/package.shelljs-shjs)
-[![npm downloads](https://img.shields.io/npm/dm/shelljs.svg?style=flat-square)](https://www.npmjs.com/package.shelljs-shjs)
+[![Travis](https://img.shields.io/travis/shelljs/shjs/master.svg?style=flat-square&label=unix)](https://travis-ci.org/shelljs/shjs)
+[![AppVeyor](https://img.shields.io/appveyor/ci/shelljs/shjs/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/shelljs/shjs/branch/master)
+[![Codecov](https://img.shields.io/codecov/c/github/shelljs/shjs/master.svg?style=flat-square&label=coverage)](https://codecov.io/gh/shelljs/shjs)
+[![npm version](https://img.shields.io/npm/v/shelljs-shjs.svg?style=flat-square)](https://www.npmjs.com/package.shelljs-shjs)
 
 `shjs` binary, formerly distributed as part of
 [ShellJS](https://github.com/shelljs/shelljs).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# shjs
-shjs binary, formerly distributed as part of shelljs
+# Shjs
+
+[![Travis](https://img.shields.io/travis/shelljs.shjs/master.svg?style=flat-square&label=unix)](https://travis-ci.org/shelljs.shjs)
+[![AppVeyor](https://img.shields.io/appveyor/ci/shelljs.shjs/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/shelljs.shjs/branch/master)
+[![Codecov](https://img.shields.io/codecov/c/github/shelljs.shjs/master.svg?style=flat-square&label=coverage)](https://codecov.io/gh/shelljs.shjs)
+[![npm version](https://img.shields.io/npm/v/shelljs.svg?style=flat-square)](https://www.npmjs.com/package.shelljs-shjs)
+[![npm downloads](https://img.shields.io/npm/dm/shelljs.svg?style=flat-square)](https://www.npmjs.com/package.shelljs-shjs)
+
+`shjs` binary, formerly distributed as part of
+[ShellJS](https://github.com/shelljs/shelljs).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+environment:
+  matrix:
+    - nodejs_version: '11'
+    - nodejs_version: '10'
+    - nodejs_version: '9'
+    - nodejs_version: '8'
+    - nodejs_version: '7'
+    - nodejs_version: '6'
+
+version: '{build}'
+
+# Install scripts. (runs after repo cloning)
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set PATH=%APPDATA%\npm;%PATH%
+  - node --version
+  - npm --version
+  - npm install
+
+matrix:
+  fast_finish: false
+
+# No need for MSBuild on this project
+build: off
+
+test_script:
+  - npm run test-with-coverage
+  - npm run lint
+
+on_success:
+  - npm run codecov -- -f coverage/lcov.info

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shelljs-shjs",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2196,12 +2196,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2216,17 +2218,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2343,7 +2348,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2355,6 +2361,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2369,6 +2376,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2376,12 +2384,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2400,6 +2410,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2480,7 +2491,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2492,6 +2504,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2613,6 +2626,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
This sets up Travis CI and AppVeyor, copying from ShellJS's configs.