### PR TITLE
fix: support scripts with arguments

### DIFF
--- a/bin/shjs
+++ b/bin/shjs
@@ -34,12 +34,7 @@ if (!test('-f', scriptName)) {
 }
 
 args = process.argv.slice(3);
-
-for (var i = 0, l = args.length; i < l; i++) {
-  if (args[i][0] !== "-"){
-    args[i] = '"' + args[i] + '"'; // fixes arguments with multiple words
-  }
-}
+process.argv = [process.argv[0], process.argv[1], ...args];
 
 var path = require('path');
 var extensions = require('interpret').extensions;

--- a/test/resources/shjs/echo-args.js
+++ b/test/resources/shjs/echo-args.js
@@ -1,0 +1,1 @@
+console.log(...process.argv);

--- a/test/shjs.js
+++ b/test/shjs.js
@@ -6,13 +6,19 @@ const shell = require('shelljs');
 
 const binPath = path.resolve(__dirname, '../bin/shjs');
 
-function runWithShjs(name) {
+function runWithShjs(name, ...args) {
   // prefix with 'node ' for Windows, don't prefix for unix
   const execPath = process.platform === 'win32'
     ? `${JSON.stringify(shell.config.execPath)} `
     : '';
   const script = path.resolve(__dirname, 'resources', 'shjs', name);
-  return shell.exec(`${execPath}${binPath} ${script}`, { silent: true });
+  let argString = args.map(arg => JSON.stringify(arg)).join(' ');
+  if (argString) {
+    argString = ' ' + argString;
+  }
+  return shell.exec(`${execPath}${binPath} ${script}${argString}`, {
+    silent: true
+  });
 }
 
 //
@@ -58,6 +64,13 @@ test('CoffeeScript extension inference', t => {
   const result = runWithShjs('coffeescript');
   t.is(result.code, 0);
   t.is(result.stdout, 'CoffeeScript: OK!\n');
+  t.falsy(result.stderr);
+});
+
+test('Multiple arguments', t => {
+  const result = runWithShjs('echo-args.js', 'hello', 'there');
+  t.is(result.code, 0);
+  t.regex(result.stdout, /hello there\n$/);
   t.falsy(result.stderr);
 });
 


### PR DESCRIPTION
This supports scripts with arguments. This was clearly working at some point in history (there is code which obviously intends to support this), but it's probably been broken since we added the "rechoir" module as a dependency.